### PR TITLE
remove IbPy requirements from CI

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,7 @@ timer-top-n=15
 cover-package=zipline
 with-doctest=1
 testmatch=(?:^|[\\b_\\.-])[Tt]est(?!ing)
+ignore-files=(?:^\.|^_,|^setup\.py$|^ib_broker\.py$)
 
 [metadata]
 description-file = README.rst


### PR DESCRIPTION
Removed requiements_live_ib from Travis and Appveyor configs
to decouple core from broker-specific requirements.

Signed-off-by: Ed Bartosh <bartosh@gmail.com>