### PR TITLE
IB Live: initialize accounts with NaN defaults

### DIFF
--- a/zipline/gens/brokers/ib_broker.py
+++ b/zipline/gens/brokers/ib_broker.py
@@ -78,7 +78,8 @@ class TWSConnection(EClientSocket, EWrapper):
         self.ticker_id_to_symbol = {}
         self.last_tick = defaultdict(dict)
         self.bars = {}
-        self.accounts = {}
+        # accounts structure: accounts[account_id][currency][value]
+        self.accounts = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: np.NaN)))
         self.accounts_download_complete = False
         self.positions = {}
         self.portfolio = {}
@@ -225,10 +226,6 @@ class TWSConnection(EClientSocket, EWrapper):
         log_message('openOrderEnd', vars())
 
     def updateAccountValue(self, key, value, currency, account_name):
-        self.accounts.setdefault(account_name, {})
-        self.accounts[account_name].setdefault(currency, {})
-        self.accounts[account_name][currency].setdefault(key, {})
-
         self.accounts[account_name][currency][key] = value
 
     def updatePortfolio(self,

--- a/zipline/gens/brokers/ib_broker.py
+++ b/zipline/gens/brokers/ib_broker.py
@@ -79,7 +79,8 @@ class TWSConnection(EClientSocket, EWrapper):
         self.last_tick = defaultdict(dict)
         self.bars = {}
         # accounts structure: accounts[account_id][currency][value]
-        self.accounts = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: np.NaN)))
+        self.accounts = defaultdict(
+            lambda: defaultdict(lambda: defaultdict(lambda: np.NaN)))
         self.accounts_download_complete = False
         self.positions = {}
         self.portfolio = {}


### PR DESCRIPTION
This PR fixes an issue when an algo tries to access account data before it is completely loaded.
