### PR TITLE
fixed badges, now they point to master

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,12 +21,12 @@ multiple brokerage support to enable on premise trading of zipline algorithms.
 See the `tutorial <http://www.zipline-live.io/tutorial>`_ and `features <http://www.zipline-live.io/features>`_ for further details.
 
 
-.. |travis status| image:: https://travis-ci.org/zipline-live/zipline.svg?branch=live
+.. |travis status| image:: https://travis-ci.org/zipline-live/zipline.svg?branch=master
     :target: https://travis-ci.org/zipline-live/zipline
 .. |appveyor status| image:: https://ci.appveyor.com/api/projects/status/jkuo1hca8v8aueym?svg=true
-   :target: https://ci.appveyor.com/project/pbharrin/zipline/branch/live
-.. |Coverage Status| image:: https://coveralls.io/repos/github/zipline-live/zipline/badge.svg?branch=live
-   :target: https://coveralls.io/github/zipline-live/zipline?branch=live
+   :target: https://ci.appveyor.com/project/pbharrin/zipline/branch/master
+.. |Coverage Status| image:: https://coveralls.io/repos/github/zipline-live/zipline/badge.svg?branch=master
+   :target: https://coveralls.io/github/zipline-live/zipline?branch=master
 .. |Apache License| image:: https://img.shields.io/badge/License-Apache%202.0-blue.svg
    :target: https://www.apache.org/licenses/LICENSE-2.0
 


### PR DESCRIPTION
The badges for travis, appveyor, coveralls now point to master.