### PR TITLE
Allow daily data frequency at live trading

### DIFF
--- a/zipline/__main__.py
+++ b/zipline/__main__.py
@@ -240,9 +240,6 @@ def run(ctx,
     if broker and broker_uri is None:
         ctx.fail("must specify broker-uri if broker is specified")
 
-    if broker and data_frequency != 'minute':
-        ctx.fail("must use '--data-frequency minute' with live trading")
-
     if broker and state_file is None:
         ctx.fail("must specify state-file with live trading")
 

--- a/zipline/algorithm_live.py
+++ b/zipline/algorithm_live.py
@@ -83,7 +83,6 @@ class LiveTradingAlgorithm(TradingAlgorithm):
         # The clock has been replaced to use RealtimeClock
         trading_o_and_c = self.trading_calendar.schedule.ix[
             self.sim_params.sessions]
-        assert self.sim_params.data_frequency == 'minute'
         assert self.sim_params.emission_rate == 'minute'
 
         minutely_emission = True

--- a/zipline/utils/run_algo.py
+++ b/zipline/utils/run_algo.py
@@ -171,7 +171,6 @@ def _run(handle_data,
     emission_rate = 'daily'
     if broker:
         emission_rate = 'minute'
-        data_frequency = 'minute'
         start = pd.Timestamp.utcnow()
         end = start + pd.Timedelta('2 day')
 


### PR DESCRIPTION
Live trading's enforcement on data_frequency == minute is too strict: 
most of the users does not have minute data.