### PR TITLE
BLD: conda build strings changed between versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ install:
     for recipe in $(ls -d conda/*/ | xargs -I {} basename {}); do
       if [[ "$recipe" = "zipline" ]]; then continue; fi
 
-      conda build conda/$recipe --python=$CONDA_PY --numpy=$CONDA_NPY --skip-existing -c quantopian -c quantopian/label/ci
+      conda build conda/$recipe --python=$CONDA_PY --numpy=$CONDA_NPY --skip-existing --old-build-string -c quantopian -c quantopian/label/ci
       RECIPE_OUTPUT=$(conda build conda/$recipe --python=$CONDA_PY --numpy=$CONDA_NPY --output)
       if [[ -f "$RECIPE_OUTPUT" && "$DO_UPLOAD" = "true" ]]; then anaconda -t $ANACONDA_TOKEN upload "$RECIPE_OUTPUT" -u quantopian --label ci; fi
     done


### PR DESCRIPTION
so using the old build string with --skip-existing, so it finds
our existing remote packages