### PR TITLE
Update calendar_utils.py

### DIFF
--- a/zipline/utils/calendars/calendar_utils.py
+++ b/zipline/utils/calendars/calendar_utils.py
@@ -25,6 +25,7 @@ _default_calendar_factories = {
     'us_futures': QuantopianUSFuturesCalendar,
 }
 _default_calendar_aliases = {
+    'SMART': 'NYSE',
     'NASDAQ': 'NYSE',
     'BATS': 'NYSE',
     'CBOT': 'CME',

--- a/zipline/utils/calendars/calendar_utils.py
+++ b/zipline/utils/calendars/calendar_utils.py
@@ -26,6 +26,7 @@ _default_calendar_factories = {
 }
 _default_calendar_aliases = {
     'SMART': 'NYSE',
+    'ARCA' : 'NYSE',
     'NASDAQ': 'NYSE',
     'BATS': 'NYSE',
     'CBOT': 'CME',


### PR DESCRIPTION
added SMART as a default calendar as it makes life easier when calling assets on exchange SMART (is an IB alias that expresses the smart routing protocol)