### PR TITLE
Update algorithm_live.py

### DIFF
--- a/zipline/algorithm_live.py
+++ b/zipline/algorithm_live.py
@@ -189,6 +189,9 @@ class LiveTradingAlgorithm(TradingAlgorithm):
         tradeable_asset['end_date'] = (pd.Timestamp('now', tz='UTC') +
                                        pd.Timedelta('10000 days'))
         tradeable_asset['auto_close_date'] = tradeable_asset['end_date']
+        # When caling symbol, subscribe to the data to make sure we have the
+        # data available when we call history or current.
+        self.broker.subscribe_to_market_data(asset)
         return asset.from_dict(tradeable_asset)
 
     def run(self, *args, **kwargs):


### PR DESCRIPTION
ENH: Subscribe to data when calling symbol()

Problem: when we ask for a lot of symbols during live trading, the market subscription with IB  can take so long that the minute passes and the functions that need the market subscription fail. 

Solution: As such when we call symbol we need to make sure we can actually get the data from the broker so it will launch a Subscribe to data action. When we ask for the symbols in before_trading_starts the environment will be ready to request data in handle_data