### PR TITLE
fix for ib date parsing

### DIFF
--- a/zipline/gens/brokers/ib_broker.py
+++ b/zipline/gens/brokers/ib_broker.py
@@ -367,7 +367,7 @@ class TWSConnection(EClientSocket, EWrapper):
             "total: {cum_qty} @ ${avg_price} "
             "exec_id: {exec_id} by client-{client_id}".format(
                 order_id=order_id, exec_id=exec_id,
-                exec_time=pd.to_datetime(exec_detail.m_time),
+                exec_time=pd.to_datetime(exec_detail.m_time, infer_datetime_format=True),
                 symbol=contract.m_symbol,
                 shares=exec_detail.m_shares,
                 price=exec_detail.m_price,


### PR DESCRIPTION
hey guys, had to add this patch to avoid the following error with IB:

[2018-07-12 19:25:58.075366] INFO: IB Broker: [2106] HMDS data farm connection is OK:ushmds (-1)
[2018-07-12 19:25:58.076006] ERROR: IB Broker: <class 'str'> returned a result with an error set
ValueError: Error parsing datetime string "20180711  06:31:21" at position 9

seemed to be working well after that.
