### PR TITLE
Allow attach_pipeline in before_trading_starts

### DIFF
--- a/zipline/algorithm.py
+++ b/zipline/algorithm.py
@@ -2374,7 +2374,7 @@ class TradingAlgorithm(object):
     # Pipeline API
     ##############
     @api_method
-    @require_not_initialized(AttachPipelineAfterInitialize())
+#    @require_not_initialized(AttachPipelineAfterInitialize())
     @expect_types(
         pipeline=Pipeline,
         name=string_types,


### PR DESCRIPTION
When live trading with pipeline, the attach_pipeline function is forced to reside in Initialise, however the pipeline object is not serialised. If we allow attach_pipeline in before_trading_starts it would work